### PR TITLE
`template auto` and partial specializaton of NTTPs

### DIFF
--- a/d1985r0.md
+++ b/d1985r0.md
@@ -431,6 +431,83 @@ select the first specialization unless an allocator object is given in
 which case the second specialization is selected. To select the third
 specialization the template arguments must be explicitly given.
 
+## Impact on the partial specialization of NTTP templates
+
+It is a common pattern in C++ to use SFINAE to constrain template
+parameter types:
+
+```cpp
+template<typename T, typename=void>
+struct A;
+
+template<template<typename> typename T, typename U>
+struct A<T<U>,std::enable_if_t<std::is_integral_v<U>>>
+{
+    // Implementation for templates with integral parameter types
+};
+
+template<template<typename> typename T, typename U>
+struct A<T<U>,std::enable_if_t<std::is_floating_point_v<U>>>
+{
+    // Implementation for templates with floating point parameter types
+};
+
+template<typename T>
+struct X {};
+
+A<X<int>> a; // Uses integral partial specialization
+```
+
+The covariant behavior of `template auto` allows a similar pattern
+to be used for NTTPs.
+
+```cpp
+template<typename T, typename=void>
+struct B;
+
+template<template<template auto> typename T, auto U>
+struct B<T<U>,std::enable_if_t<std::is_integral_v<decltype(U)>>>
+{
+    // Implementation for templates with integral parameter types
+};
+
+template<template<typename> typename T, typename U>
+struct B<T<U>,std::enable_if_t<std::is_floating_point_v<decltype(U)>>>
+{
+    // Implementation for templates with floating point parameter types
+};
+
+template<int I>
+struct Y {};
+
+B<Y<5>> b; // Uses integral partial specialization
+```
+
+This pattern cannot currently be used with NTTPs as `auto` behaves
+contravariantly:
+
+```cpp
+template<typename T, typename=void>
+struct C;
+
+template<template<auto> typename T, auto U>
+struct C<T<U>,std::enable_if_t<std::is_integral_v<decltype(U)>>>
+{};
+
+template<int I>
+struct Z1 {};
+
+template<auto I>
+struct Z2 {};
+
+C<Z1<5>> c1; // Error: T does not match Z1
+C<Z2<5>> c2; // Ok: NTTP can only be `auto`
+```
+
+With partial specialization, covariant behavior is desired. We rely on
+SFINAE to check that `T` accepts `U` and wish to accept any type of template
+which can take an integral NTTP in this example. `template auto` allows
+such a pattern to work without modifying the behavior of `auto`.
 
 ## Impacts on the specialization of variable templates
 

--- a/d1985r0.md
+++ b/d1985r0.md
@@ -9,6 +9,8 @@ author:
     email: <mateusz.pusz@gmail.com>
   - name: Gašper Ažman
     email: <gasper.azman@gmail.com>
+  - name: Colin MacLean
+    email: <ColinMacLean@lbl.gov>
 ---
 
 # Introduction
@@ -471,7 +473,7 @@ struct B<T<U>,std::enable_if_t<std::is_integral_v<decltype(U)>>>
     // Implementation for templates with integral parameter types
 };
 
-template<template<typename> typename T, typename U>
+template<template<typename> typename T, auto U>
 struct B<T<U>,std::enable_if_t<std::is_floating_point_v<decltype(U)>>>
 {
     // Implementation for templates with floating point parameter types
@@ -629,6 +631,9 @@ production of this proposal.
 
 Gašper would likewise like to thank his employer, Citadel Securities Europe,
 LLC, for supporting his attendance in committee meetings.
+
+Colin MacLean would also like to thank his employer, Lawrence Berkeley National
+Laboratory, for supporting his ISO C++ Committee efforts.
 
 A big thanks also to the members of the BSI C++ panel for their review and
 commentary.


### PR DESCRIPTION
This section could also be useful in justifying the covariant nature of `template auto`