### PR TITLE
Further exploration of the co/contravariant approach

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -13,6 +13,8 @@ author:
     email: <bengt.gustafsson@beamways.com>
   - name: Colin MacLean
     email: <ColinMacLean@lbl.gov>
+  - name: James Touton
+    email: <bekenn@gmail.com>
 ---
 
 # Introduction
@@ -77,8 +79,8 @@ A simpler example we should also use is `fwd`, which merely forwards its second
 template argument to its first, without the attempt of being variadic:
 
 ```cpp
-template <template <typename> typename F, typename arg>
-using fwd = F<arg>;
+template <template <typename> typename F, typename Arg>
+using fwd = F<Arg>;
 ```
 
 # Proposed Solution
@@ -105,27 +107,34 @@ apply<H, G>;   // OK, G<int>
 
 ## "Mathematically Correct" version
 
-We need to introduce both a an _anything_ parameter (which we'll spell
-`template auto` as above), and a _wildcard_ parameter (which, given the work in
-pattern matching, we are probably free to spell `__`).
+We need to introduce an _anything_ template parameter which can bind to _any_
+template argument; we'll spell this `template auto` as above). We also need an
+_unrestricted_ template _template-parameter_ that can bind to _any_ type template;
+we will specify this by omitting the template parameter list.
 
 We can then define `apply` as follows:
 
 ```cpp
-template <template <__...> typename F, template auto... Args>
+template <template typename F, template auto... Args>
 using apply = F<Args...>;
 ```
 
-`fwd` is similar:
+`fwd` uses a _wildcard_ parameter (which, given the work in pattern matching,
+we are probably free to spell `__`):
 
 ```cpp
-template <template <__> typename F, temmplate auto arg>
-using fwd = F<arg>;
+template <template <__> typename F, temmplate auto Arg>
+using fwd = F<Arg>;
 ```
 
 In this mechanism, `__` really is an "unconstrained" pattern match, and does not
-declare a parameter kind - it's illegal to declare a `template <__ x> struct foo
-{};`, for instance.
+declare a parameter kind - it's illegal to declare a `template <__ X> struct foo
+{};`, for instance. The `__` can only be used in the parameter list of a template
+_template-parameter_. Whereas `template auto` denotes a template parameter capable
+of binding to any template argument of _any_ kind, `__` denotes a template parameter
+with a concrete but _unspecified_ kind; that is, you can't tell from the declaration
+what a valid template argument might be — its kind might be type, non-type, template,
+or even `template auto`, but exactly _which_ of those is not known.
 
 ## Mechanism
 
@@ -146,9 +155,9 @@ struct X<T> {
   using type = T;
 };
 
-template <auto val>
-struct X<val> : std::integral_constant<decltype(val), val> {
-  // val is an NTTP
+template <auto Val>
+struct X<Val> : std::integral_constant<decltype(Val), Val> {
+  // Val is an NTTP
 };
 
 template <template <typename> F>
@@ -189,7 +198,8 @@ universal template parameter only in:
 
 - *template-parameter-list* as the declaration of such a parameter
 - *template-argument-list* as the usage of such a parameter. It must bind
-  exactly to a declared `template auto` template parameter.
+  exactly to a template parameter declared as `template auto` or with an
+  unknown kind.
 
 This avoids any parsing issues by being conservative. We can always extend
 the grammar to allow usage in more contexts later.
@@ -214,13 +224,24 @@ pattern-match it out.
 #### What late checking looks like
 
 If we chose to go with late checking, we'd be doing what we currently do with
-dependent identifiers - they are treated as values, and require "typename" and
-"template" to disambiguate.
+dependent identifiers - they are by default interpreted as values, and require
+`typename` and `template` to disambiguate.
+
+```cpp
+template <template auto Arg>
+void f() {
+  using type = template Arg<int>; // assumes Arg is a template
+  auto value = Arg.foo(); // assumes Arg is a value
+  auto x = Arg(); // assumes Arg is a callable object (e.g. a function pointer)
+  auto y = typename Arg(); // assumes Arg is a default-constructible type
+  auto z = Arg::member; // assumes Arg is a type
+};
+```
 
 The primary use-case of passing these identifiers as template arguments remains
-OK, but and treating them like this also eases specification, and is more
-consistent with the way the language currently works. This is the more
-"adventurous" option, however.
+OK, and treating them like this also eases specification, and is more consistent
+with the way the language currently works. This is the more "adventurous" option,
+however.
 
 ### Template _template-parameter_ binding
 
@@ -230,13 +251,13 @@ usage: parsing, and substitution.
 Let's take `apply` again:
 
 ```cpp
-template <template <__...> typename F, template auto... Args>
+template <template typename F, template auto... Args>
 using apply = F<Args...>;
 ```
 
-This *parses*, because `F` is *declared* as a class template parameter taking
-a pack of `template auto`, while `Args` is being expanded into a place that
-takes `template auto` parameters.
+This *parses* under both the eager and late checking models, because `F` is
+*declared* as a type template of unknown arity and with unknown parameter
+kinds.
 
 When we pass a metafunction such as `is_same` as `F`:
 
@@ -250,13 +271,29 @@ instantiation time.
 
 ## Clarifying examples
 
+### `specializable` concept
+
+The `apply` and `fwd` metafunctions can be constrained using the `specializable`
+concept:
+
+```cpp
+template <template typename TT, template auto... Args>
+concept specializable = requires { typename TT<Args>; };
+
+template <template typename F, template auto... Args> requires specializable<F, Args...>
+using apply = F<Args...>;
+
+template <template <__> typename F, template auto Arg> requires specializable<F, Arg>
+using fwd = F<Arg>;
+```
+
 ### Single parameter examples
 
 ```cpp
-template <int>                            struct takes_int {};
-template <typename T>                     using  takes_type = T;
-template <template auto>                  struct takes_anything {}
-template <template <typename> typename F> struct takes_metafunc {};
+template <int>                          struct takes_int {};
+template <typename T>                   using  takes_type = T;
+template <template auto>                struct takes_anything {}
+template <template <typename> typename> struct takes_metafunc {};
 
 template <template <template auto> typename F, template auto Arg>
 struct fwd {
@@ -264,12 +301,12 @@ struct fwd {
 }; // ok, correct definition
 
 void f() {
-  fwd<takes_int, 1>{};    // ok; type = takes_int<1>
+  fwd<takes_int, 1>{};    // ok; type is takes_int<1>
   fwd<takes_int, int>{};  // error, takes_int<int> invalid
-  fwd<takes_type, int>{}; // ok; type = takes_type<int>
-  fwd<takes_anything, int>{}; // ok; type = takes_anything<int>
-  fwd<takes_anything, 1>{};   // ok; type = takes_anything<1>
-  fwd<takes_metafunc, takes_int>; // ok; type = takes_metafunc<takes_int>
+  fwd<takes_type, int>{}; // ok; type is takes_type<int> (synonym for int)
+  fwd<takes_anything, int>{}; // ok; type is takes_anything<int>
+  fwd<takes_anything, 1>{};   // ok; type is takes_anything<1>
+  fwd<takes_metafunc, takes_int>; // ok; type is takes_metafunc<takes_int>
   fwd<takes_metafunc, takes_metafunc>{}; // error (1)
 }
 ```
@@ -288,13 +325,13 @@ struct is_same : std::false_type {};
 template <template auto V>
 struct is_same<V, V> : std::true_type {};
 
-template <template auto V, template auto ... Args>
+template <template auto V, template auto... Args>
 struct count : std::integral_constant<
     size_t,
     (is_same<V, Args>::value + ...)> {};
 
 // ok, ints = 2:
-constexpr size_t ints = count<int, 1, 2, int, is_same, int>::value;
+constexpr size_t ints = count<int, 1, 2, 3, int, is_same, int>::value;
 ```
 
 ### Example of parsing ambiguity (if late check)
@@ -314,6 +351,39 @@ a declaration or a multiplication.
 
 If we treated `A` as just a dependent name, this always parses as a
 multiplication.
+
+This can be resolved by using the `template` and `typename` keywords to
+disambiguate, as we already do for other dependent names; for instance, if we
+want to treat `A * a` as a pointer declaration, we can add the `typename` keyword:
+
+```cpp
+template <template auto A>
+struct X {
+  void f() { typename A * a; }  // A must be a type
+};
+```
+
+At first glance, this appears to defeat the purpose of declaring `A` as
+`template auto`, as it assumes that `A` is a type, but this may be combined with
+`if constexpr` to limit the scope of the assumption:
+
+```cpp
+template <template auto> inline constexpr bool is_value = false;
+template <auto V> inline constexpr bool is_value<V> = true;
+
+template <template auto A>
+struct X {
+  void f() {
+    if constexpr (is_value<A>) {
+      auto x = A * a;
+    }
+    else {
+      typename A* a = nullptr;
+    }
+};
+```
+
+Such usage is expected to be extremely rare.
 
 Original example from [@P0945R0]:
 
@@ -336,17 +406,16 @@ This was the introductory example. Please refer to the [Proposed Solution].
 Further example: `curry`:
 
 ```cpp
-template <typename <template auto...> typename F,
-          template auto ... Args1>
+template <template typename F, template auto... Args1>
 struct curry {
-  template <template auto... Args2>
+  template <template auto... Args2> requires specializable<F, Args1..., Args2...>
   using func = F<Args1..., Args2...>;
 };
 ```
 
 ## Making dependent `static_assert(false)` work
 
-Dependent static assert idea is described in [@P1936R0] and [@P1830R1]. In the
+Dependent static assert is described in [@P1936R0] and [@P1830R1]. In the
 former the author writes:
 
 > Another parallel paper [@P1830R1] that tries to solve this problem on the library level is
@@ -381,18 +450,18 @@ the universal template parameter, we can write a concept for that easily as
 follows.
 
 ```cpp
-// is_specialization_of
-template <typename T, template <template auto...> typename Type>
-inline constexpr bool is_specialization_impl = false;
+// specialization_of
+template <typename T, template typename Type>
+inline constexpr bool is_specialization = false;
 
-template <template auto... Params, template <template auto...> typename Type>
-inline constexpr bool is_specialization_impl<Type<Params...>, Type> = true;
+template <template auto... Params, template typename Type>
+inline constexpr bool is_specialization<Type<Params...>, Type> = true;
 
-template <typename T, template <template auto...> typename Type>
-concept is_specialization_of = is_specialization_impl<T, Type>;
+template <typename T, template typename Type>
+concept specialization_of = is_specialization<T, Type>;
 ```
 
-With the above  we are able to easily constrain various utilities taking class templates:
+With the above we are able to easily constrain various utilities taking class templates:
 
 ```cpp
 template <auto N, auto D>
@@ -401,7 +470,7 @@ struct ratio {
   static constexpr decltype(D) d = D;
 };
 
-template <is_specialization_of<ratio> R1, is_specialization_of<ratio> R2>
+template <specialization_of<ratio> R1, specialization_of<ratio> R2>
 using ratio_mul = simplify<ratio<
     R1::n * R2::n,
     R1::d * R2::d
@@ -412,7 +481,7 @@ or create named concepts for them:
 
 ```cpp
 template <typename T>
-concept is_ratio = is_specialization_of<ratio>;
+concept is_ratio = specialization_of<ratio>;
 
 template <is_ratio R1, is_ratio R2>
 using ratio_mul = simplify<ratio<
@@ -424,7 +493,7 @@ using ratio_mul = simplify<ratio<
 This concept can then be easily used everywhere:
 
 ```cpp
-template <is_specialization_of<std::vector> V>
+template <specialization_of<std::vector> V>
 void f(V& v) {
   // valid for any vector
 }
@@ -448,7 +517,7 @@ struct alias<T> { using value = T; }
 template <auto V>
 struct alias<V> : std::integral_constant<decltype(V), V> {};
 
-template <template <template auto...> typename Arg>
+template <template typename Arg>
 struct alias<Arg> {
   template <template auto... Args> using value = Arg<Args...>;
 };
@@ -471,7 +540,7 @@ Z<1> z; // error, alias<1>::value is not a type
 ## Impacts on the specialization of class templates
 
 Universal template arguments enable what appears like overloading of
-class templates by specializing a unimplemented primary template
+class templates by partially specializing an unimplemented primary template
 taking a pack of universal template parameters.
 
 ```cpp
@@ -503,6 +572,10 @@ constructor implicit deduction guide. The explicit deduction guides
 select the first specialization unless an allocator object is given in
 which case the second specialization is selected. To select the third
 specialization the template arguments must be explicitly given.
+
+<!-- From James: This whole section looks completely wrong to me, particularly the
+claim that the design of auto NTTPs somehow prevents you from doing this.  Let's
+talk this out.
 
 ## Impact on the partial specialization of NTTP templates
 
@@ -581,6 +654,7 @@ With partial specialization, covariant behavior is desired. We rely on
 SFINAE to check that `T` accepts `U` and wish to accept any type of template
 which can take an integral NTTP in this example. `template auto` allows
 such a pattern to work without modifying the behavior of `auto`.
+-->
 
 ## Impacts on the specialization of variable templates
 
@@ -609,7 +683,7 @@ template <template <typename> typename Pred, typename Tuple>
 constexpr size_t tuple_find() { return tuple_find<Pred, 0, Tuple>(); }
 
 // Helper to bind the first arguments of a provided template
-template <template <template auto...> TPL, template auto... Bs> struct curry {
+template <template typename TPL, template auto... Bs> struct curry {
     template <template auto... Ts> using func = TPL<Bs..., Ts>;
 };
 
@@ -620,7 +694,7 @@ template <template <typename> typename Pred, typename Tuple>
 constexpr size_t tuple_find_v<Pred, Tuple> = tuple_find<Pred, Tuple>();
 
 template <template <typename> typename Pred, size_t Pos, typename Tuple>
-constexpr size_t tuple_find_v<Pred, Tuple> = tuple_find<Pred, Pos, Tuple>();
+constexpr size_t tuple_find_v<Pred, Pos, Tuple> = tuple_find<Pred, Pos, Tuple>();
 
 // Convenience specialization for use with binary predicate
 template <template <typename, typename> typename Pred, typename M, typename Tuple> 
@@ -643,7 +717,7 @@ variable `tuple_find_v` to regain the symmetry with current
 tuple oriented metafunctions such as `tuple_size_v` and
 `tuple_element_t`.
 
-Given a further overloaded constexpr function `tuple_size` we could simplify
+Given a further overloaded constexpr function `tuple_find` we could simplify
 this to:
 
 ```cpp
@@ -669,14 +743,14 @@ to template matching.
 
 The examples in this section are pending discussion with reflection authors.
 
-Importantly, the authors do not see how one could write `is_specialization_of`
+Importantly, the authors do not see how one could write `specialization_of`
 with the current reflection facilities, because one would have no way to
 pattern-match. This is, however, also pending discussion with the authors of
 reflection.
 
 ## Library fundamentals II TS detection idiom
 
-TODO. Concievably simplifies the implementation and makes it far more
+TODO. Conceivably simplifies the implementation and makes it far more
 general.
 
 # Covariance and Contravariance
@@ -713,9 +787,10 @@ template <template <A> typename f>
 using puts_a = void;
 template <B> using takes_b = void;
 template <A> using takes_a = void;
+
 using x = puts_b<takes_a>; // ok
 // Error, constraint mismatch (gcc)
-// clang accepts (in error)
+// clang requires -frelaxed-template-template-args for correct behavior
 using w = puts_a<takes_b>;
 ```
 
@@ -737,11 +812,12 @@ template <template <int> typename f> using puts_int = void;
 template <template <auto> typename f> using puts_auto = void;
 template <int> using takes_int = void;
 template <auto> using takes_auto = void;
+
 using x = puts_int<takes_auto>; // OK
 using w = puts_auto<takes_int>; // Error, but MSVC, GCC and clang all accept
 ```
 
-TODO: Ask James Touton where in the standard this is made an error.
+This behavior was specified in [@P0522R0].
 
 Function pointers do not convert in either co or contravariant ways:
 
@@ -814,7 +890,7 @@ The above is correct, but _useless_ - it requires `f`s signature to be
 any kind of unary template metafunction, so we can pass in something like
 `template <int x> using int_constant = std::integral_constant<int, x>;`.
 
-As a thought experiment, let's call the covariant version of `template auto`
+As a thought experiment, let's call the contravariant version of `template auto`
 (with the meaning "deduce this from the argument") `__`:
 
 ```cpp
@@ -911,15 +987,15 @@ Whether to:
   single defined meaning for both, or;
 - (**easy**) reserve *one* token sequence (`template auto`) and switch its
   meaning in a context-dependent manner, losing the ability to mean
-  `template auto` in a _template template-parameter_, since in that context,
+  `template auto` in a template _template-parameter_, since in that context,
   `template auto` would mean `__`.
 
 # Further work (for context and planning): Cohesive template parameter theory
 
-This work in **not a part of the proposal**, but we mention it here because this
+This work is **not a part of the proposal**, but we mention it here because this
 paper falls into the wider framework of cleaning up template parameter theory.
 
-This section is basically wholy thought up by James Touton. We thank him for his
+This section is basically wholly thought up by James Touton. We thank him for his
 ideas.
 
 The core of the problem is that `...` behaves in a context-dependent manner; the


### PR DESCRIPTION
It's so late in my time zone that it's now early, and I'm tired.  Apologies for the quhadtaneccccccccccc hal .tdas.whaa?

So... my edits here are clearly wider-ranging than requested.  Please pay careful attention to them.  My intent here is not (necessarily) that you take this as-is, but rather to serve as a basis for ongoing discussion, and that you use this as a guide to making your own edits.  One thing that seems clear to me is that this is not ready for submission today, but that's fine; we can keep using D drafts for discussion, and the next mailing is only a month away.

In particular, I've updated almost every example to use the "mathematically correct" approach in order to showcase what that actually looks like.  What I'd actually like to see here is the two approaches side-by-side, but I don't know how to format that in a readable manner, and I doubt we want _that_ much duplication.

I've removed entirely (via html comment tag) the "Impacts on the partial specialization of NTTP templates" section because I don't agree with the basic premise that `template auto` enables a scenario that was previously unavailable, and it seems to be relying on SFINAE where a C++20 approach would use concepts.

I've also made some consistency changes (such as capitalizing all template parameter names, removing the `is_` prefix from (nearly) all concept names), as well as a few editorial corrections.