### PR TITLE
Added section on dependent names

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -275,7 +275,7 @@ A dependent name specified as a universal template parameter may not be used
 in any expression where the type/value information must be known for parsing:
 
 ```cpp
-template<template auto... T>
+template<template auto T>
 void f()
 {
   std::cout << template auto T*2; // Error: Parse fails because T could be a type

--- a/d1985r3.md
+++ b/d1985r3.md
@@ -222,6 +222,78 @@ OK, but and treating them like this also eases specification, and is more
 consistent with the way the language currently works. This is the more
 "adventurous" option, however.
 
+### Dependent names
+
+Universal template parameters are always dependent names. When a
+universal template parameter is used in an expression, it is parsed as a
+value by default. They can be disambiguated as a type by using `typename`
+as with other dependent names. To defer the type/value decision, `template
+auto` maybe used to perserve the name as a universal template. This allows
+the universal template parameter to be forwarded to another template.
+
+```cpp
+template<template auto Arg> void f()
+{
+  std::cout << Arg; // Arg is parsed a value
+  std::cout << sizeof(typename Arg); // Arg is parsed as a type
+
+  // Type/value decision is deferred to myclass
+  std::cout << myclass<template auto Arg>::value;
+}
+```
+
+The `typename auto` specifier may also be used to defer type/value lookup and
+form universal template parameters from other dependent names. This enables
+utility structs to perform transformations on packs of universal template
+parameters:
+
+
+```cpp
+template<typename T>
+struct unwrap_nttps;
+
+template<typename T>
+struct unwrap_nttps<T>
+{
+  using result = T;
+};
+
+template<typename T, T t>
+struct unwrap_nttps<std::integral_constant<T,t>>
+{
+  static inline constexpr T result = t;
+};
+```
+
+`template auto unwrap_nttps<Pack>::result...` may result in a template parameter
+pack of mixed types and NTTPs. By specifying the name of the dependent type as
+a universal template using `template auto`, the type/value state is
+deferred until it can be looked up during instantiation and a universal template
+parameter pack can be formed.
+
+A dependent name specified as a universal template parameter may not be used
+in any expression where the type/value information must be known for parsing:
+
+```cpp
+template<template auto... T>
+void f()
+{
+  std::cout << template auto T*2; // Error: Parse fails because T could be a type
+  myclass<template auto T*2> a; // Error: The same rule applies in template arguments.
+  template auto T*2; // Error: Parse fails because meaning differs between type/value
+
+  if constexpr (std::is_value_v<template auto T>)
+  {
+    std::cout << T*2; // Ok. T is parsed as a value.
+  }
+};
+
+```
+
+Because `template auto` is not implicit even on universal template parameters and
+all dependent names are parsed as values by default, the `if constexpr` disambiguation
+is able to treat the parameter as a value.
+
 ### Template _template-parameter_ binding
 
 We have to consider the two phases of class template (and template alias)


### PR DESCRIPTION
Adding the section for dependent names and how UTPs are always treated as dependent names.

I noticed `std::is_value_v<T>` is a case where contravariant behavior is desired. This could be constrained with concepts (`std::is_type_v<T>` also must be true).

This is for issue #14 and #19