### PR TITLE
make_unique CTAD example

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -505,8 +505,7 @@ An overload to implement this would look something like:
 template<template<typename auto...> class C, typename... Ps> 
 auto make_unique(Ps&&... ps)
 {
-    return unique_ptr<decltype(C(std::forward<Ps>(ps)...))>{
-            new C(std::forward<Ps>(ps)...)};
+    return unique_ptr<decltype(C(std::forward<Ps>(ps)...))>(new C(std::forward<Ps>(ps)...));
 }
 ```
 

--- a/d1985r3.md
+++ b/d1985r3.md
@@ -23,6 +23,13 @@ type traits.
 
 # Change Log
 
+## R2 -> R3
+
+Added make_unique example.
+
+Changed first example to use an int NTTP instead of a template template parameter
+to make it easier to understand.
+
 ## R1 -> R2
 
 Having found overwhelming support for the feature in EWGI, and a concern
@@ -57,15 +64,14 @@ struct G { using type = X; };
 static_assert(std::is_same<apply<G, int>, G<int>>{}); // OK
 ```
 
-As soon as `G` tries to take any kind of NTTP (non-type template-parameter)
+As soon as `F` tries to take any kind of NTTP (non-type template-parameter)
 or a template _template-parameter_, `apply` becomes impossible to write; we
 need to provide analogous parameter kinds for every possible combination of
 parameters:
 
 ```cpp
-template <template <typename> typename F>
-using H = F<int>;
-apply<H, G> // error, can't pass H as arg1 of apply, and G as arg2
+template <int I> struct H {};
+apply<H, 3>  // error, can't pass H as arg1 of apply, nor 3 as arg2.
 ```
 
 While `apply` is very simple, a metafunction like `bind` or `curry` runs into
@@ -100,7 +106,7 @@ template <template <template auto...> typename F, template auto... Args>
 using apply = F<Args...>;
 
 apply<G, int>; // OK, G<int>
-apply<H, G>;   // OK, G<int>
+apply<H, 3>;   // OK, H<3>
 ```
 
 ## "Mathematically Correct" version
@@ -468,6 +474,46 @@ Z<int> z1; // ok, decltype(z1)::value = int
 Z<1> z; // error, alias<1>::value is not a type
 ```
 
+## Bringing CTAD to make_unique (and make_shared etc,)
+
+With the introduction of CTAD a discrepancy was created which favors using plain new instead of
+make_unique as the latter needs the template arguments of a template class to be spelled out.
+
+With universal template parameters we can add overloads to make_unique
+which make CTAD work in these situations:
+
+```cpp
+auto a = std::tuple(1, true, 'a');       // ok
+auto ap = new std::tuple(1, true, 'a');  // ok
+
+// not ok in C++20.
+auto up = std::make_unique<std::tuple>(1, true, 'a');   
+
+int arr[] = {1, 2, 3};
+
+auto s = std::span(arr);                 // ok
+auto sp = new std::span(arr);            // ok
+
+// not implementable in C++20 as span has a NTTP.
+auto sup = std::make_unique<std::span>(arr);  
+
+```
+
+An overload to implement this would look something like:
+
+```cpp
+template<template<typename auto...> class C, typename... Ps> 
+auto make_unique(Ps&&... ps)
+{
+    return unique_ptr<decltype(C(std::forward<Ps>(ps)...))>{
+            new C(std::forward<Ps>(ps)...)};
+}
+```
+
+Note that the decltype is required as there is no deduction guide for plain pointers, this is however not a
+problem specific to the universal template overload.
+
+
 ## Impacts on the specialization of class templates
 
 Universal template arguments enable what appears like overloading of
@@ -743,7 +789,7 @@ using w = puts_auto<takes_int>; // Error, but MSVC, GCC and clang all accept
 
 TODO: Ask James Touton where in the standard this is made an error.
 
-Function pointers do not convert in either co or contravariant ways:
+Function pointers do not convert in either co- or contravariant ways:
 
 ```cpp
 struct X {}; struct Y : X {};


### PR DESCRIPTION
Found an interesting example in a long forgotten repo clone. It allows:

auto p = std::make_unique<std::tuple>(1, "hej"s);

This also starts the revision history list (with the risk of it becoming too detailed).
