### PR TITLE
Merged the dependent names and using universal templates in code

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -191,7 +191,7 @@ Here #2 fails late at #1 and #3 succeeds just as for the easy definition.
 
 ## Mechanism
 
-#### Additional possibilities offered by late ckecing
+#### Additional possibilities offered by late checking
 
 With late checking UTPs can be used as dependent names. As we can create
 predicates to test for their actual kind during instantiation we can create
@@ -221,79 +221,6 @@ template<template auto P> void f()
     }
 }
 ```
-
-
-### Dependent names
-
-Universal template parameters are always dependent names. When a
-universal template parameter is used in an expression, it is parsed as a
-value by default. They can be disambiguated as a type by using `typename`
-as with other dependent names. To defer the type/value decision, `template
-auto` maybe used to perserve the name as a universal template. This allows
-the universal template parameter to be forwarded to another template.
-
-```cpp
-template<template auto Arg> void f()
-{
-  std::cout << Arg; // Arg is parsed a value
-  std::cout << sizeof(typename Arg); // Arg is parsed as a type
-
-  // Type/value decision is deferred to myclass
-  std::cout << myclass<template auto Arg>::value;
-}
-```
-
-The `typename auto` specifier may also be used to defer type/value lookup and
-form universal template parameters from other dependent names. This enables
-utility structs to perform transformations on packs of universal template
-parameters:
-
-
-```cpp
-template<typename T>
-struct unwrap_nttps;
-
-template<typename T>
-struct unwrap_nttps<T>
-{
-  using result = T;
-};
-
-template<typename T, T t>
-struct unwrap_nttps<std::integral_constant<T,t>>
-{
-  static inline constexpr T result = t;
-};
-```
-
-`template auto unwrap_nttps<Pack>::result...` may result in a template parameter
-pack of mixed types and NTTPs. By specifying the name of the dependent type as
-a universal template using `template auto`, the type/value state is
-deferred until it can be looked up during instantiation and a universal template
-parameter pack can be formed.
-
-A dependent name specified as a universal template parameter may not be used
-in any expression where the type/value information must be known for parsing:
-
-```cpp
-template<template auto T>
-void f()
-{
-  std::cout << template auto T*2; // Error: Parse fails because T could be a type
-  myclass<template auto T*2> a; // Error: The same rule applies in template arguments.
-  template auto T*2; // Error: Parse fails because meaning differs between type/value
-
-  if constexpr (std::is_value_v<template auto T>)
-  {
-    std::cout << T*2; // Ok. T is parsed as a value.
-  }
-};
-
-```
-
-Because `template auto` is not implicit even on universal template parameters and
-all dependent names are parsed as values by default, the `if constexpr` disambiguation
-is able to treat the parameter as a value.
 
 ### Template _template-parameter_ binding
 
@@ -376,19 +303,19 @@ limitations we saw before `if constexpr` was introduced: Function templates
 often had to rely on helper structs to do simple things.
 
 
-### Allowing unversal template parameters in code
+### Dependent Names
 
 To make this feature easier to use we also propose that universal template
 parameters are usable in code. To make parsing possible we then have to
 disambiguate universal template parameters according to dependent name rules.
 
-Unfortunately always disambiguating as value prevents `using type =
-X<U>;` above from working as expected. U would be automatically disambiguated as
-a value at parse time and if it turns out not to be a value at instantiation
-time this is an error.
+The dependent name rules shall be modified such that dependent names passed as
+template arguments are promoted as universal template parameters. This allows
+`using type = X<U>;` above to work as expected and slighlty extends "Down with
+`typename`!".
 
-We actually have a version of this problem already with overloaded template
-functions and dependent names:
+This rule shall apply to dependent names other than universal template
+parameters, as well:
 
 ```cpp
 template<typename T> int f() { return sizeof(T); }
@@ -396,128 +323,94 @@ template<auto V> int f() { return V; }
 
 template<typename T> int caller()
 {
-    return f<??? T::name>();
+    return f<T::name>();
 }
 ```
 
-Here the second f is called if T::name is a value, but if it is a type an
-instantiation error is caused, rather than the first f being called.
+Because `T::name` is a dependent type used as a template argument, it is
+promoted to a universal template parameter and the correct `f()` is called.
 
-With universal template parameters this problem will be more articulated,
-especially when universal template parameters are forwarded directly as in:
+This rule also applies when universal template parameters are not explicitly
+used, and thus slightly extends "Down with `typename`!".
 
 ```cpp
-template<template auto U> int caller2()
-{
-    return f<U>();
-}
+std::vector<T::name> v;
 ```
 
-This compiles with C++20 disambiguation rules but always tries to call the
-second overload of f as U is always treated as a value, with the surprising result
-that `caller2` can't be instantiated with a type even though f has an overload
-for types.
+In C++20, `T::name` would be parsed as a value. However, according to this new
+rule, `T::name` would become a universal template parameter, which would then
+bind to `std::vector` as a type.
 
-### Explicit ambiguaton syntax
-
-To avoid this issue an _ambiguation_ syntax which prevents the automatic
-disambiguation can be introduced. The ambiguation syntax can be the same as used
-for the declaration of a universal template parameter, just like for typename
-and template. We can then use this to resolve the problem in `caller2`.
+This promotion to a universal template parameter only occurs if the template
+argument expression is a dependent name. If the dependent name is part of a
+larger expression, the expression itself is not a dependent name and the rule
+no longer applies:
 
 ```cpp
-template<template auto U> int caller2()
+template<typename auto T, typename U>
+void caller2()
 {
-    return f<template auto U>();
+  // Error: T* contains a dependent name but is not itself a dependent name.
+  // Therefore, T is parsed as a value and the expression is nonsensical.
+  f<T*>();
+
+  // Ok: dependent name disambiguated as a type
+  f<typename T*>();
+
+  // Ok: T*2 isn't itself a dependent name, so T is parsed as a value
+  f<T*2>();
+
+  // Error: U::name* contains a dependent name but is not itself a dependent
+  // name. Therefore, U::name is parsed as a value and the expression is
+  // nonsensical.
+  f<U::name*>();
+
+  // Ok: Correctly disambiguated
+  f<typename U::name*>();
+
+  using tpl = T<U>; // Error: T is parsed as a value.
+  using tpl2 = template T<U>; // Ok: Correctly disambiguated
+
+  typename (template T<U>)::type i; // Note: double disambiguation
 }
 ```
 
-Note however that the first formulation of `caller2` is still valid code, which
-makes ambiguation error prone in addition to being tedious.
+Because this rule only applies to dependent names used by themselves as template
+arguments, type/value information is not needed immediately and this decision can
+be safely deferred. By keeping C++20 dependent name rules for all other contexts,
+problems that could arise from defering all kind checking until insantiation are
+avoided.
 
-If this type of ambiguation is also allowed for dependent names it can be used
-to resolve the `caller` problem above too. This extension would unify universal
-template parameters and dependent names further.
+The promotion of dependent names to universal template parameters also applies
+to template argument packs and enables utility structs to perform transformations
+on packs of template parameters involving mixes of types and NTTPs:
 
-
-#### Deferring kind checking to instantiation
-
-To avoid having to ambiguate universal template parameters kind matching can be
-deferred to instantiation time. The template argument is still parsed as a
-constant-expression but if it consists of only a universal template parameter no
-check against the kind the template argument will be bound to is done during
-parsing. Such deferred checking is already required if the template is in itself
-dependent.
-
-Now universal template parameters work as we have reason to expect from them:
 
 ```cpp
-template<typename auto U> int caller3()
+template<typename T>
+struct unwrap_nttps;
+
+template<typename T>
+struct unwrap_nttps<T>
 {
-    auto u = f<U>();        // Instantiates for values and types
-    using type = X<U>;      // Instantiates for all kinds.
+  using result = T;
+};
 
-    // Can fail instantiation if argument kind is wrong.
-    auto v = U;             // Parses U as a value.
-    using t = U*;           // Parses U as a type thanks to "down with typename".
-
-    // Error during parse
-    U x;                    // Error: U is parsed as a value
-    template<typename T> using tpl = U<T>;  // Error: U is parsed as a value.
-
-    // Disambiguation useful outside of template argument:
-    typename U x;
-    template<typename T> using tpl = template U<T>;
-    typename template U<int> i;  // Note: New double disambiguation
-    template U<int> vi;          // Future: variable template bound to U
-}
+template<typename T, T t>
+struct unwrap_nttps<std::integral_constant<T,t>>
+{
+  static inline constexpr T result = t;
+};
 ```
 
-With this rule the original formulation of `caller2` works as intended: At parse
-time the universal template parameter U is treated as a value, but as the
-constant-expression has no further contents its kind is re-evaluated at
-substitution time and the resulting kind is matched against the template
-parameter kind.
+`U<unwrap_nttps<Pack>::result...>` causes an argument pack of universal templates
+to be formed.
 
-There are two options regarding in which cases to do this re-evaluation. One is
-to do it only if the template parameter bound to is universal in which case it
-doesn't solve the issue with overloaded function templates taking different
-template parameter kinds. The other option is to re-evaluate whenever the
-template _argument_ is a constant-expression consisting of only a universal
-template parameter. This handles the function overload case too.
-
-The same rule can be extended to dependent names, which would resolve `caller`
-without need for ambiguation. Note that no C++20 code is broken by this change
-as `caller` is currently only callable when T::name resolves to a value.
-
-
-#### Make use of known template parameter kinds
-
-When parsing a template argument in a template argument list the expected kind
-of the template argument is most often known from the template. This could be
-exploited to reduce the disambiguation needed in template arguments:
-
-```cpp
-template<typename auto U> int caller4()
-{
-    std::vector<U*> v;
-}
-```
-
-This would fail to parse using even deferred kind checking as `U*` is an invalid
-expression. However, if the compiler was mandated to check that vector's first
-template parameter is a typename it could correctly parse `U*` under the same
-rule as a type alias can.
-
-A drawback with this feature is that as some templates are dependent at parse
-time this simplification can not always be employed. While this should be fairly
-easy for programmers to see it is still one more rule to remember when thinking
-about whether disambiguation is needed.
-
-Due to this and as this possibility was a late discovery and opens up some
-possible new risks we do not propose to extend the proposal in this way at this
-time.
-
+There is no need to ambiguate dependent names as universal template parameters outside
+of this narrow context where implicit promotion to universal template parameter can be
+used. For instance, using `typename auto` to prevent a universal template from being
+parsed as a value in the expression `template auto T*2` or `template auto T*` wouldn't
+be helpful because the template kind must be known in these expressions.
 
 ## Clarifying examples
 


### PR DESCRIPTION
These sections had some overlap and I think the rules proposed regarding dependnet names in the "using universal templates in code" section overly complicated things. What I propose instead is to modify the dependnet name rules to promote dependnet names to universal template parameters in the narrow context of dependnet names used as template arguments (see text for detailed explanation). Because dependent names and UTPs are only visible as UTPs in this narrow context, there's no need for re-evaluation or anything like that.