### PR TITLE
Universal  Aliases + text shuffling etc.

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -17,9 +17,8 @@ author:
 
 # Introduction
 
-We propose a universal template parameter and associated cleanups to make it useful for template metaprogramming.
-This will allow for a generic `apply` and other higher-order template
-metafunctions, including certain type traits.
+We propose a universal template parameter and associated cleanups to make it useful for template metaprogramming. This will allow
+for a generic `apply` and other higher-order template metafunctions, including certain type traits.
 
 # Change Log
 
@@ -248,7 +247,7 @@ Let's count the number of types in the argument list, for instance:
 ```cpp
 template <int... xs> using sum = box<(0 + ... + xs)>;
 template <template auto X> using boxed_is_typename = box<is_typename_v<X>>;
-static_assert(2 == map_reduce<sum, boxed_is_typename, 1, int, long, sum>::result);
+static_assert(2 == map_reduce<sum, boxed_is_typename, int, 1, long, std::vector>::result);
 ```
 
 With variable-template template-parameters, we don't need to box `is_typename_v`, and we can define `map_reduce` slightly better:
@@ -264,7 +263,7 @@ using map_reduce_better = Reduce<Map<Args>...>;
 and we can use it more comfortably as well:
 
 ```cpp
-static_assert(2 == map_reduce_better<sum, is_typename_v, 1, int, long, sum>::result);
+static_assert(2 == map_reduce_better<sum, is_typename_v, int, 1, long, std::vector>::result);
 ```
 
 **Note:** alas, we still need `sum` to be a box. We won't ever have universal
@@ -272,248 +271,15 @@ aliases, but we *can* have universal dependent expressions.
 
 **Note:** the template-auto template-template parameter of `map_reduce_better`.
 
-# Proposed Solution
 
-Introduce a way to specify a truly universal template parameter that can bind
-to anything usable as a template argument.
-
-There are two ways we can go about specifying this, depending on whether we want
-to be mathematically correct, or less powerful, imprecise, but "easy" to use.
-(See the co/contravariance discussion below).
-
-## "Easy" version
-
-We spell it `template auto`. The syntax is somewhat up for debate in this
-version of the solution.
-
-```cpp
-template <template <template auto...> typename F, template auto... Args>
-using apply = F<Args...>;
-
-template <typename Type> struct G {};
-template <int i> struct H {};
-template <template <typename> typename Template> struct J {};
-
-apply<G, int>; // OK, G<int>
-apply<H, 3>;   // OK, H<3>
-apply<J, G>;   // OK, J<G>
-apply<J, H>;   // error, H takes int.
-```
-
-## "Mathematically Correct" version
-
-We need to introduce both a an _anything_ parameter (which we'll spell
-`template auto` as above), and a _wildcard_ parameter (which, given the work in
-pattern matching, we are probably free to spell `__`).
-
-We can then define `apply` as follows:
-
-```cpp
-template <template <__...> typename F, template auto... Args>
-using apply = F<Args...>;
-```
-
-`fwd` is similar:
-
-```cpp
-template <template <__> typename F, temmplate auto arg>
-using fwd = F<arg>;
-```
-
-In this mechanism, `__` really is an "unconstrained" pattern match, and does not
-declare a parameter kind - it's illegal to declare a `template <__ x> struct foo
-{};`, for instance.
-
-### Example of the difference between mathematically correct and easy versions.
-
-The basic premise about "mathematically correct" is that the user of the
-template template parameter must be able to instantiate it in all ways that the
-declaration indicates. This means that if a template parameter is declared
-`template<template auto...> typename F` only an argument with the same
-declaration can be substituted, as this is the only way that F can be
-instantiated with any number of template parameters of any kind.
-
-In the "Easy" version it is enough that the template argument can be instantiated with
-_some_ template parameters out of the ones permitted by the template parameter
-declaration.
-
-
-```cpp
-template<template<template auto...> class TPL> void f()
-{
-    TPL<int, 3> myObject;       // #1
-}
-
-f<std::vector>();               // #2
-f<std::array>();                // #3
-```
-
-With the easy definition both instantiations at #2 and #3 are fine, but then we
-get substitution failure for #2 at #1 as `std::vector` can't take a numerical
-second template argument. At #3 we get no errors as f() _happened_ to instantiate
-TPL only with template argument kinds that the `std::array` supports.
-
-With the mathematically correct definition both #2 and #3 fail to substitute into TPL
-as none of `std::array` and `std::vector` have a variadic universal template parameter,
-and thus can't support whatever instances that f() may want to create.
-
-To be able to pass any template as the argument to a template parameter in the
-mathematically correct definition we must use another syntax for the template
-parameters of the template template parameter, such as __. This allows any class
-template to be used as the template argument and defers checking until inside
-the instantation process.
-
-```cpp
-template<template<__...> class TPL> void f()
-{
-    TPL<int, 3> myObject;       // #1
-}
-
-f<std::vector>();               // #2
-f<std::array>();                // #3
-```
-Here #2 fails late at #1 and #3 succeeds just as for the easy definition.
-
-## Mechanism
-
-#### Additional possibilities offered by late ckecing
-
-With late checking UTPs can be used as dependent names. As we can create
-predicates to test for their actual kind during instantiation we can create
-function templates which can be compiled for different kinds without having to
-resort to intermediate class templates. Instead we can use `if constexpr` as
-we have become used to in recent years.
-
-```cpp
-template<template auto P> struct is_value : public std::false_type {};
-template<auto T> struct is_value : public std::true_type {};
-
-template<template auto P> using is_value_v = is_value<P>::value;
-
-
-template<template auto P> void f()
-{
-    if constexpr (is_value_v<P>) {
-        // Default interpretation is value as P is a dependent name.
-        std::cout << P;                            
-    }
-    else if constexpr (is_typename_v<P>) {
-        // An UTP can be disambiguated like a dependent name
-        std::cout << ”A type of size” << sizeof(typename P);
-    }
-    else {
-        std::cout << ”P is a template”;
-    }
-}
-```
-
-
-### Dependent names
-
-Universal template parameters are always dependent names. When a
-universal template parameter is used in an expression, it is parsed as a
-value by default. They can be disambiguated as a type by using `typename`
-as with other dependent names. To defer the type/value decision, `template
-auto` maybe used to perserve the name as a universal template. This allows
-the universal template parameter to be forwarded to another template.
-
-```cpp
-template<template auto Arg> void f()
-{
-  std::cout << Arg; // Arg is parsed a value
-  std::cout << sizeof(typename Arg); // Arg is parsed as a type
-
-  // Type/value decision is deferred to myclass
-  std::cout << myclass<template auto Arg>::value;
-}
-```
-
-The `typename auto` specifier may also be used to defer type/value lookup and
-form universal template parameters from other dependent names. This enables
-utility structs to perform transformations on packs of universal template
-parameters:
-
-
-```cpp
-template<typename T>
-struct unwrap_nttps;
-
-template<typename T>
-struct unwrap_nttps<T>
-{
-  using result = T;
-};
-
-template<typename T, T t>
-struct unwrap_nttps<std::integral_constant<T,t>>
-{
-  static constexpr T result = t;
-};
-```
-
-`template auto unwrap_nttps<Pack>::result...` may result in a template parameter
-pack of mixed types and NTTPs. By specifying the name of the dependent type as
-a universal template using `template auto`, the type/value state is
-deferred until it can be looked up during instantiation and a universal template
-parameter pack can be formed.
-
-A dependent name specified as a universal template parameter may not be used
-in any expression where the type/value information must be known for parsing:
-
-```cpp
-template<template auto T>
-void f()
-{
-  std::cout << template auto T*2; // Error: Parse fails because T could be a type
-  myclass<template auto T*2> a; // Error: The same rule applies in template arguments.
-  template auto T*2; // Error: Parse fails because meaning differs between type/value
-
-  if constexpr (std::is_value_v<template auto T>)
-  {
-    std::cout << T*2; // Ok. T is parsed as a value.
-  }
-};
-
-```
-
-Because `template auto` is not implicit even on universal template parameters and
-all dependent names are parsed as values by default, the `if constexpr` disambiguation
-is able to treat the parameter as a value.
-
-### Template _template-parameter_ binding
-
-We have to consider the two phases of class template (and template alias)
-usage: parsing, and substitution.
-
-Let's take `apply` again:
-
-```cpp
-template <template <__...> typename F, template auto... Args>
-using apply = F<Args...>;
-```
-
-This *parses*, because `F` is *declared* as a class template parameter taking
-a pack of `template auto`, while `Args` is being expanded into a place that
-takes `template auto` parameters.
-
-When we pass a metafunction such as `is_same` as `F`:
-
-```cpp
-using result = apply<std::is_same, int, 1>; // error
-```
-
-everything is known, so the compiler is free to check dependent expansions at
-instantiation time.
-
-
-## Mechanisms
+# Mechanism
 
 This chapter describes how universal template parameters work. First the basic
 specialization based mechanism is described, and then how the similarities to
 dependent names can be exploited to increase the functionality, with several
 levels of refinement.
 
-### Specializing class templates on parameter kind
+## Specializing class templates on parameter kind
 
 The new universal template parameter introduces similar generalizations as
 the `auto` universal NTTP did; in order to make it possible to pattern-match
@@ -560,7 +326,7 @@ limitations we saw before `if constexpr` was introduced: Function templates
 often had to rely on helper structs to do simple things.
 
 
-### Allowing unversal template parameters in code
+## Allowing unversal template parameters in code
 
 To make this feature easier to use we also propose that universal template
 parameters are usable in code. To make parsing possible we then have to
@@ -602,7 +368,7 @@ second overload of f as U is always treated as a value, with the surprising resu
 that `caller2` can't be instantiated with a type even though f has an overload
 for types.
 
-### Explicit ambiguaton syntax
+## Explicit ambiguaton syntax
 
 To avoid this issue an _ambiguation_ syntax which prevents the automatic
 disambiguation can be introduced. The ambiguation syntax can be the same as used
@@ -624,7 +390,7 @@ to resolve the `caller` problem above too. This extension would unify universal
 template parameters and dependent names further.
 
 
-#### Deferring kind matching to instantiation
+## Deferring kind matching to instantiation
 
 To avoid having to ambiguate universal template parameters kind matching can be
 deferred to instantiation time. The template argument is still parsed as a
@@ -674,7 +440,7 @@ without need for ambiguation. Note that no C++23 code is broken by this change
 as `caller` is currently only callable when T::name resolves to a value.
 
 
-#### Make use of known template parameter kinds
+## Make use of known template parameter kinds
 
 When parsing a template argument in a template argument list the expected kind
 of the template argument is most often known from the template. This could be
@@ -701,13 +467,74 @@ Due to this and as this possibility was a late discovery and opens up some
 possible new risks we do not propose to extend the proposal in this way at this
 time.
 
-#### Automatic disambiguation when :: is used
+
+# Universal aliases
+
+A universal alias is a name given to a dependent name or universal template
+parameter. The universal alias is in itself a dependent name just like a
+universal tmeplate parameter. 
+
+Teh grammar for a universal alias is simply:
+
+universal-alias:<br>
+    **template auto** identifier = template-argument ;
+
+The box example is now trivial. 
+
+```cpp
+template<typename auto U> struct box {
+    typename auto result = U;
+};
+```
+
+With this definition the map_reduce example above can be further refined:
+
+```cpp
+template<template<template auto> template auto Map,
+          template<template auto...> template auto Reduce,
+          template auto... Args>
+template auto map_reduce_best = Reduce<Map<Args>...>;
+```
+
+and we can use it more comfortably as well:
+
+```cpp
+template<int... xs> constexpr int sum = (0 + ... + xs);
+static_assert(2 == map_reduce_best<sum, is_typename_v, int, 1, long, std::vector>);
+```
+**Note:** Now Map is also declared as a `template auto` metafunction, meaning
+that it could be a class template or as in the case of `sum` a variable
+template.
+
+**Note:** Now we no longer need `sum` to be a box. map_reduce_best is a universal
+alias template. We still need to disambiguate these when used. In this example however,
+as the result of sum is a value, we don't have to disambiguate inside the
+static_assert.
+
+
+# Automatic disambiguation when :: is applied
+
+To ensure that universal template parameters work exactly as dependent names we
+need to clean up how nested dependent names work. This can be done without
+breaking backwards compatibility, it just makes a few more cases valid, by
+generalizing a rule.
+
+The lengthy description below sums up to this TL:DR style conclusion:
+
+Let `::` automatically disambiguate its left hand side as a type, and let
+typename disambiguate the last dependent name as a type.
+
+This is enough to make everything work consistently and unsurprisingly for both
+dependent names and universal template parameters.
+
+
+## Digging into the nested disambiguation jungle
 
 Today there we have a rather weird situation when it comes to disambiguation of
 nested dependent names, i.e. when a dependent name contains another dependent
 name. As only types can have dependent names in them you would imagine that the
 `ftype` dependent name in the example below would automatically be disambiguated
-as a type. This is not the case:
+as a type so that ::svalue could be applied. This is not the case:
 
 ```cpp
 template<typename T> struct S {
@@ -740,9 +567,9 @@ template<typename T> struct S {
 };
 ```
 
-For v2 typename disambiguates the template instance as being a type. This is
-required as the template instance would otherwise be assumed to be an instance
-of a varable template.
+For v2 the leading typename disambiguates the template instance as being a type.
+This is required as the template instance would otherwise be assumed to be an
+instance of a varable template.
 
 For v3 typename disambiguates _both_ the type-instance and its member stype
 as types, consistent with the v1 declaration.
@@ -750,7 +577,7 @@ as types, consistent with the v1 declaration.
 How x3 can be initialized when x1 can't is hard to understand, maybe the
 reasons can be traced back to a time when variable templates were not a thing,
 and thus the tpl instance must be a type, which allows `::svalue` to be applied. This
-is not consistent with the non-template case.
+is not consistent with the non-template case x1.
 
 We can also reverse the order between the template and the typename, so that T
 must contain a type containing a template. This template can be a class template
@@ -763,31 +590,33 @@ template<typename T> struct S {
 };
 ```
 
-Just as for the opposite order of template and type this works, and it seems
-that the `template` keyword helps interpreting `ftype` as a type.
+Just as for the opposite order of template and type this works, the leading
+typename again disambiguates both ftype and the template instance as types when
+declaring v4, while the x4 initialization remains inconsistent with x1.
 
 Clearly, if we want universal template parameters to work like dependent names
-we don't want dependent names to behave this strangely.
+we don't want dependent names to behave this strangely. Below all the cases
+above are listed inside one class template taking a universal template
+parameter U.
 
 ```cpp
 template<template auto U> struct S {
-    int x = U;              // U is treated as a value as long as it is not disambiguated
-    typename U v5;          // U can be disambiguated to typename.
+    int x = U;                      // U is treated as a value as long as it is not disambiguated
+    typename U v5;                  // U can be disambiguated to typename.
     int x5 = template U<int, 3>;    // U can be disambiguated to template. Its instance defaults to a value
-    typename template U<int, 3> v5; // But can be re-disambiguated to a type.
+    typename template U<int, 3> v5; // The instance can be re-disambiguated to a type.
 
     // U can be a type containing a value or subtype
     int x6 = U::svalue;
     typename U::stype v6;
 
-    // U can be disambiguated as a template. Its instance is automatically disambiguated to type
-    // if followed by ::
+    // U can be disambiguated as a template. The template instance is automatically disambiguated
+    // to a type if followed by ::
     int x7 = template U<int, 3>::svalue;
     typename template U<int, 3>::stype v7;
 
-    // The U template instance can be disambiguated to type.
-
-    // Finally U can be disambiguated as a type containing a template.
+    // Finally U can be disambiguated as a type containing a template, which is
+    done by the trailing :: preceeding the template keyword.
     int x8 = U::template tpl<int, 3>;
     typename U::template tpl<int, 3> v8;
 };
@@ -795,11 +624,15 @@ template<template auto U> struct S {
 
 Claiming that `U::svalue` is a value makes universal template parameters work
 "better" than nested dependent names do today, as x1 above does not compile.
-This breaks the correspondence. To rectify this we should change the
-rule for nested dependent names to automatically disambiguate all but the last
-dependent name as types. This does not change the meaning of the `v1`
-declaration above but makes the `x1` initializer a valid value value. The x3 and
-x4 initializers behave the same as today, but with a more understandable rationale.
+This breaks the consistency. 
+
+To rectify this we should change the rule for typename disambiguation to only
+affect the last of a set of nested dependent names, while a `::` always
+automatically disambiguates a dependent name to the left as a type. This does
+not change the meaning of the `v1` declaration above but makes the `x1`
+initializer a value as ftype is disambiguated by the trailing `::`and svalue is
+a value as there is no leading `typename`. The x3 and x4 initializers behave the
+same as today, but with a more understandable rationale.
 
 TODO: This section needs to be written the other way around: How the T::name can be
 replaced by U, how this can't be done textually and then that this gives us the
@@ -830,10 +663,21 @@ This looks like an explicit instantiation of a class template U. I think this is
 not a real problem as expression statements can't be in namespace scope, while
 explicit template instantiations _must_ be in namespace scope. 
 
+However, variable declarations are allowed in namespace scope so this would be
+scarily similar to the above explicit template instantiatio:
 
-## Clarifying examples
+template U<int, 3> x;
 
-### Single parameter examples
+However, this would require that U is a universal alias in namespace scope,
+which we can easily forbid, as there are no dependent names in namespace scope
+that it can alias. Note that this is true only for non-template universal
+aliases, the templated variety is very useful in namespace scope, as shown by
+the map_reduce_best example above.
+
+
+# Clarifying examples
+
+## Single parameter examples
 
 ```cpp
 template <int>                            struct takes_int {};
@@ -859,7 +703,7 @@ void f() {
 (1): `takes_metafunc` is not a metafunction on a *type*, so
      `takes_metafunc<takes_metafunc>` is invalid (true as of *C++98*).
 
-### Pack Expansion Example
+## Pack Expansion Example
 
 It is interesting to think about what happens if one expands a
 non-homogeneous pack of these. The result should not be surprising:
@@ -879,7 +723,7 @@ struct count : std::integral_constant<
 constexpr size_t ints = count<int, 1, 2, int, is_same, int>::value;
 ```
 
-### Example of parsing ambiguity (if late check)
+## Example of parsing ambiguity (if late check)
 
 The reason for eager checking is that not doing that could introduce parsing
 ambiguities. Example courtesy of [@P0945R0], and adapted:
@@ -895,7 +739,8 @@ The issue is that we do not know how to parse `f()`, since `A * a;` is either
 a declaration or a multiplication.
 
 If we treated `A` as just a dependent name, this always parses as a
-multiplication.
+multiplication. To treat A as a typename and a as a variable being declared the
+A has to be disambiguated as any dependent name.
 
 Original example from [@P0945R0]:
 
@@ -1429,6 +1274,109 @@ reflection.
 TODO. Concievably simplifies the implementation and makes it far more
 general.
 
+# Discussion on contravariance correctness
+
+Introduce a way to specify a truly universal template parameter that can bind
+to anything usable as a template argument.
+
+There are two ways we can go about specifying this, depending on whether we want
+to be mathematically correct, or less powerful, imprecise, but "easy" to use.
+(See the co/contravariance discussion below).
+
+## "Easy" version
+
+We spell it `template auto`. The syntax is somewhat up for debate in this
+version of the solution.
+
+```cpp
+template <template <template auto...> typename F, template auto... Args>
+using apply = F<Args...>;
+
+template <typename Type> struct G {};
+template <int i> struct H {};
+template <template <typename> typename Template> struct J {};
+
+apply<G, int>; // OK, G<int>
+apply<H, 3>;   // OK, H<3>
+apply<J, G>;   // OK, J<G>
+apply<J, H>;   // error, H takes int.
+```
+
+## "Mathematically Correct" version
+
+We need to introduce both a an _anything_ parameter (which we'll spell
+`template auto` as above), and a _wildcard_ parameter (which, given the work in
+pattern matching, we are probably free to spell `__`).
+
+We can then define `apply` as follows:
+
+```cpp
+template <template <__...> typename F, template auto... Args>
+using apply = F<Args...>;
+```
+
+`fwd` is similar:
+
+```cpp
+template <template <__> typename F, temmplate auto arg>
+using fwd = F<arg>;
+```
+
+In this mechanism, `__` really is an "unconstrained" pattern match, and does not
+declare a parameter kind - it's illegal to declare a `template <__ x> struct foo
+{};`, for instance.
+
+### Example of the difference between mathematically correct and easy versions.
+
+The basic premise about "mathematically correct" is that the user of the
+template template parameter must be able to instantiate it in all ways that the
+declaration indicates. This means that if a template parameter is declared
+`template<template auto...> typename F` only an argument with the same
+declaration can be substituted, as this is the only way that F can be
+instantiated with any number of template parameters of any kind.
+
+In the "Easy" version it is enough that the template argument can be instantiated with
+_some_ template parameters out of the ones permitted by the template parameter
+declaration.
+
+
+```cpp
+template<template<template auto...> class TPL> void f()
+{
+    TPL<int, 3> myObject;       // #1
+}
+
+f<std::vector>();               // #2
+f<std::array>();                // #3
+```
+
+With the easy definition both instantiations at #2 and #3 are fine, but then we
+get substitution failure for #2 at #1 as `std::vector` can't take a numerical
+second template argument. At #3 we get no errors as f() _happened_ to instantiate
+TPL only with template argument kinds that the `std::array` supports.
+
+With the mathematically correct definition both #2 and #3 fail to substitute into TPL
+as none of `std::array` and `std::vector` have a variadic universal template parameter,
+and thus can't support whatever instances that f() may want to create.
+
+To be able to pass any template as the argument to a template parameter in the
+mathematically correct definition we must use another syntax for the template
+parameters of the template template parameter, such as __. This allows any class
+template to be used as the template argument and defers checking until inside
+the instantation process.
+
+```cpp
+template<template<__...> class TPL> void f()
+{
+    TPL<int, 3> myObject;       // #1
+}
+
+f<std::vector>();               // #2
+f<std::array>();                // #3
+```
+Here #2 fails late at #1 and #3 succeeds just as for the easy definition.
+
+
 # Covariance and Contravariance
 
 ## As of C++23
@@ -1640,6 +1588,9 @@ using apply3 = F<x, y, z>;
 The reason we discarded this one is that it is very terse for something that
 should not be commonly used, and as such uses up valuable real-estate.
 
+
+
+
 # Compendium: Open Design Questions
 
 See discussions above to inform these choices; this section just compiles the
@@ -1652,6 +1603,7 @@ Whether to:
 - specify **eager** checking with conservative rules on use of identifiers, or;
 - specify **late** checking on instantiation and use the C++23
   rules for parsing dependent expressions for them.
+
 
 ## Easy or Correct
 

--- a/d1985r3.md
+++ b/d1985r3.md
@@ -134,7 +134,7 @@ using r3 = apply1<takes_template, takes_template>; // takes_template<takes_templ
 The non-contrived example is the `apply` metafunction, achievable like so:
 
 ```cpp
-template <template <template auto...> typename F, typename auto... Args>
+template <template <template auto...> typename F, template auto... Args>
 using apply = F<Args...>; // easy peasy!
 
 using r1 = apply<std::array, int, 3>; // ok, std::array<int, 3>
@@ -247,7 +247,7 @@ Let's count the number of types in the argument list, for instance:
 ```cpp
 template <int... xs> using sum = box<(0 + ... + xs)>;
 template <template auto X> using boxed_is_typename = box<is_typename_v<X>>;
-static_assert(2 == map_reduce<sum, boxed_is_typename, int, 1, long, std::vector>::result);
+static_assert(2 == map_reduce<boxed_is_typename, sum, int, 1, long, std::vector>::result);
 ```
 
 With variable-template template-parameters, we don't need to box `is_typename_v`, and we can define `map_reduce` slightly better:
@@ -263,7 +263,7 @@ using map_reduce_better = Reduce<Map<Args>...>;
 and we can use it more comfortably as well:
 
 ```cpp
-static_assert(2 == map_reduce_better<sum, is_typename_v, int, 1, long, std::vector>::result);
+static_assert(2 == map_reduce_better<is_typename_v, sum, int, 1, long, std::vector>::result);
 ```
 
 **Note:** alas, we still need `sum` to be a box. We won't ever have universal
@@ -401,7 +401,7 @@ required if the template is in itself dependent.
 Now universal template parameters work as we have reason to expect from them:
 
 ```cpp
-template<typename auto U> int caller3()
+template<template auto U> int caller3()
 {
     auto u = f<U>();        // Instantiates for values and types
     using type = X<U>;      // Instantiates for all kinds.
@@ -447,7 +447,7 @@ of the template argument is most often known from the template. This could be
 exploited to reduce the disambiguation needed in template arguments:
 
 ```cpp
-template<typename auto U> int caller4()
+template<template auto U> int caller4()
 {
     std::vector<U*> v;
 }
@@ -482,8 +482,8 @@ universal-alias:<br>
 The box example is now trivial. 
 
 ```cpp
-template<typename auto U> struct box {
-    typename auto result = U;
+template<template auto U> struct box {
+    template auto result = U;
 };
 ```
 
@@ -500,7 +500,7 @@ and we can use it more comfortably as well:
 
 ```cpp
 template<int... xs> constexpr int sum = (0 + ... + xs);
-static_assert(2 == map_reduce_best<sum, is_typename_v, int, 1, long, std::vector>);
+static_assert(2 == map_reduce_best<is_typename_v, sum, int, 1, long, std::vector>);
 ```
 **Note:** Now Map is also declared as a `template auto` metafunction, meaning
 that it could be a class template or as in the case of `sum` a variable
@@ -664,7 +664,7 @@ not a real problem as expression statements can't be in namespace scope, while
 explicit template instantiations _must_ be in namespace scope. 
 
 However, variable declarations are allowed in namespace scope so this would be
-scarily similar to the above explicit template instantiatio:
+scarily similar to the above explicit template instantiation:
 
 template U<int, 3> x;
 
@@ -879,7 +879,7 @@ auto sup = std::make_unique<std::span>(arr);
 An overload to implement this would look something like:
 
 ```cpp
-template<template<typename auto...> class C, typename... Ps> 
+template<template<template auto...> class C, typename... Ps> 
 auto make_unique(Ps&&... ps)
 {
     return unique_ptr<decltype(C(std::forward<Ps>(ps)...))>(new C(std::forward<Ps>(ps)...));


### PR DESCRIPTION
- Changed wording in the first few sentenses so it makes more sense, to me at least.

- Moved initial text about contravaraince back to the latter parts. Still much cleanup to be done on that section. And cutting!

- Removed the old Mechanism chapter and promoted my Mechanisms chapter to the new Mechanism chapter.

- Added a section on universal aliases, pending understanding why this is impossible. This includes a further simplifited map_reduce_best.

- Improved the text on nested dependent names and their disambiguation and made a shorter intro with just the conclusion.