### PR TITLE
Added a few outstanding issues around UAs.

### DIFF
--- a/d1985r3.md
+++ b/d1985r3.md
@@ -469,6 +469,40 @@ alias template. We still need to disambiguate these when used. In this example, 
 as the result of `sum` is a value, we don't have to disambiguate inside the
 `static_assert`.
 
+## Remaining questions around universal aliases
+
+There are a few questions that arise around UAs that don't apply to UTPs.
+
+### Must the initializer be constexpr
+
+In P0945's version of universal aliases a initializer of value kind did not have
+to be constexpr, the universal alias was just another name for a variable or
+function.
+
+With UTPs we don't have to pose this question as template parameters are always
+constexpr. With UAs the answer is not given, and more investigation is needed to
+see if allowing not-constexpr initializers is a useful and implementable idea.
+
+### Are UAs always dependent
+
+For UTPs the sole reason for existence is that they are dependent, i.e. of
+unknown kind until instantiation time.
+
+For UAs there are at least three possibilities:
+
+- Mandate that the initiializer is also dependent. This gives good diagnostics
+  opportuniities and there are other ways to alias names of known names (except
+  values, where references are not really the same thing).
+
+- Allow the initializer to be non-dependent but keep the alias dependent anyway.
+
+- Allow the initializer to be non-dependent and let the kind of the alias follow
+  the initializer's kind if known. This is closest to P0945 and, expecially if
+  the initializer is not required to be constexpr, the most usable feature.
+
+Note that the choice here affects the naming. Maybe a name like dependent_name
+is not as appropriate if the resulting entity is not always dependent.
+
 
 # Automatic disambiguation when :: is applied
 

--- a/d1985r3.md
+++ b/d1985r3.md
@@ -428,9 +428,6 @@ static_assert(sum_unwrapped<1, std::integral_constant<short, 2s>> == 3);
 A universal alias is a name given to a dependent name or universal template
 parameter. The universal alias is in itself a dependent name, just like a UTP.
 
-This is an optional part of the paper, but it just fell out of the grammar when
-implementing in clang, and it obviates the need for a `box<X>`.
-
 The grammar for a universal alias is simply:
 
 universal-alias:<br>
@@ -480,10 +477,12 @@ to be constexpr, the universal alias was just another name for a variable or
 function.
 
 With UTPs we don't have to pose this question as template parameters are always
-constexpr. With UAs the answer is not given, and more investigation is needed to
-see if allowing not-constexpr initializers is a useful and implementable idea.
+constexpr. With UAs the answer is not given, but in this proposal we define that
+they must be. This means that the grammar production with template-argument as
+the initializer is correct, with one of its alternatives being
+constant-expression.
 
-### Are UAs always dependent
+### Are universal aliases always dependent
 
 For UTPs the sole reason for existence is that they are dependent, i.e. of
 unknown kind until instantiation time.
@@ -500,9 +499,8 @@ For UAs there are at least three possibilities:
   the initializer's kind if known. This is closest to P0945 and, expecially if
   the initializer is not required to be constexpr, the most usable feature.
 
-Note that the choice here affects the naming. Maybe a name like dependent_name
-is not as appropriate if the resulting entity is not always dependent.
-
+In this proposal we take the more conservative approach that the initializer of
+an universal alias must be dependent. 
 
 # Automatic disambiguation when :: is applied
 
@@ -1098,7 +1096,9 @@ template auto f<float>(float y);
 ```
 
 While this is not a parsing problem as such as long as UTPs are just that, it
-would prevent using the same spelling for an universal alias extension.
+would prevent using the same spelling for an universal alias. **But as noted
+elsewhere non-template universal aliases can't be in namespace scope as their
+initializers can never be dependent. **
 
 
 In a future standard version variable templates may be allowed as template


### PR DESCRIPTION
There was one more thing but I forgot.

Actually I want to somehow get a "single" structured binding, that's what we need for a value alias, and what P0945 offered but we never got. The names in a SB have the properties we're after. No cost, no lifetime, just an alias name. Another proposal probably. Then we can safely say that UAs are always constexpr and the result is always dependent.